### PR TITLE
Final solution for task #8

### DIFF
--- a/java/ru/ifmo/ctddev/solutions/crawler/WebCrawler.java
+++ b/java/ru/ifmo/ctddev/solutions/crawler/WebCrawler.java
@@ -1,27 +1,203 @@
 package ru.ifmo.ctddev.solutions.crawler;
 
+import info.kgeorgiy.java.advanced.crawler.CachingDownloader;
 import info.kgeorgiy.java.advanced.crawler.Crawler;
+import info.kgeorgiy.java.advanced.crawler.Document;
 import info.kgeorgiy.java.advanced.crawler.Downloader;
 import info.kgeorgiy.java.advanced.crawler.Result;
+import info.kgeorgiy.java.advanced.crawler.URLUtils;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class WebCrawler implements Crawler {
+    private final Downloader downloader;
+    private final ExecutorService downloadExecutor;
+    private final Semaphore maxDownloads;
+    private final Semaphore maxExtractors;
+    private final ConcurrentHashMap<String, Semaphore> hosts = new ConcurrentHashMap<>();
+    private final int perHost;
 
     public WebCrawler(Downloader downloader, int downloaders, int extractors, int perHost) {
-
+        int threads;
+        try {
+            threads = Math.addExact(downloaders, extractors);
+        }
+        catch (ArithmeticException e) {
+            threads = Integer.MAX_VALUE;
+        }
+        this.downloader       = downloader;
+        this.downloadExecutor = Executors.newFixedThreadPool(threads);
+        this.maxDownloads     = new Semaphore(downloaders);
+        this.maxExtractors    = new Semaphore(extractors);
+        this.perHost          = perHost;
     }
 
-    @Override
-    public Result download(String url, int depth) {
+    protected class Cache {
+        protected ConcurrentHashMap<String, String> urls = new ConcurrentHashMap<>();
+        protected ConcurrentHashMap<String, IOException> errors = new ConcurrentHashMap<>();
+
+        Cache() {}
+    }
+
+    protected class DownloadTask implements
+            Callable<List<String>>,
+            Function<String, List<String>> {
+        private String url;
+        private Cache cache;
+
+        DownloadTask(String url, Cache cache) {
+            this.url = url;
+            this.cache = cache;
+        }
+
+        @Override
+        public List<String> call() {
+            // 'cause ConcurrentHashMap cannot store null
+            return Objects.nonNull(cache.urls.putIfAbsent(url, url)) ? null :  this.apply(url);
+        }
+
+        @SuppressWarnings("unused")
+        private Semaphore retreive(String url, Semaphore semaphore) {
+            return semaphore == null
+                ? new Semaphore(WebCrawler.this.perHost)
+                : semaphore;
+        }
+
+        @Override
+        public List<String> apply(String s) {
+            Document document = null;
+            List<String> result = null;
+            String host;
+
+            try {
+                host = URLUtils.getHost(s);
+            }
+            catch (MalformedURLException e) {
+                e.printStackTrace();
+                return null;
+            }
+
+            Semaphore semaphore = WebCrawler.this.hosts.compute(host, this::retreive);
+            semaphore.acquireUninterruptibly();
+            WebCrawler.this.maxDownloads.acquireUninterruptibly();
+            try {
+                document = WebCrawler.this.downloader.download(s);
+            }
+            catch (IOException e) {
+                cache.errors.putIfAbsent(s, e);
+            }
+            finally {
+                WebCrawler.this.maxDownloads.release();
+                semaphore.release();
+                if (document == null) {
+                    return null;
+                }
+            }
+
+            WebCrawler.this.maxExtractors.acquireUninterruptibly();
+            try {
+                result = document.extractLinks();
+            }
+            catch (IOException e) {
+                cache.errors.putIfAbsent(s, e);
+            }
+            finally {
+                WebCrawler.this.maxExtractors.release();
+            }
+            return result;
+        }
+    }
+
+
+    private static <T> T extractFuture(Future<T> future) {
+        try {
+            return future.get();
+        }
+        catch (ExecutionException | InterruptedException e) {
+            e.printStackTrace();
+        }
         return null;
     }
 
     @Override
-    public void close() {
+    public Result download(String s, int i) {
+        List<String> allUrls = new ArrayList<>(2 << i);
+        List<String> currentUrls = Collections.singletonList(s);
+        Cache cache = new Cache();
 
+        for (int depth = 0; depth < i; depth++) {
+            if (currentUrls.size() == 0)
+                break;
+
+            allUrls.addAll(currentUrls);
+            List<Callable<List<String>>> downloads = currentUrls.stream()
+                    .map(v -> new DownloadTask(v, cache) )
+                    .collect(Collectors.toCollection(LinkedList::new));
+            try {
+                currentUrls = downloadExecutor.invokeAll(downloads).stream()
+                        .filter(Objects::nonNull)
+                        .map(WebCrawler::extractFuture)
+                        .filter(Objects::nonNull)
+                        .reduce(new ArrayList<>(i), (all, one) -> { all.addAll(one); return all; });
+                currentUrls.removeAll(allUrls);
+            }
+            catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        allUrls.removeAll(cache.errors.keySet());
+
+        return new Result(allUrls, cache.errors);
     }
 
-    public static void main(String[] args) {
-        //WebCrawler url [downloads [extractors [perHost]]]
-        System.out.println("WebCrawler");
+    @Override
+    public void close() {
+        try {
+            downloadExecutor.shutdownNow();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    public static void main(String... args) throws Exception {
+        int depth = 1, downloadors = Integer.MAX_VALUE,
+            extractors = Integer.MAX_VALUE, perHost = Integer.MAX_VALUE;
+
+        if (args.length < 1) {
+            throw new RuntimeException("Url is missing in command-line arguments.");
+        }
+
+        String url = args[0];
+        for (int i = 1; i < args.length && i < 5; i++) {
+            int n = Integer.valueOf(args[i]);
+            switch (i) {
+                case 1: depth       = n; break;
+                case 2: downloadors = n; break;
+                case 3: extractors  = n; break;
+                case 4: perHost     = n; break;
+            }
+        }
+
+        Result result;
+        try (Crawler crawler = new WebCrawler(new CachingDownloader(), downloadors, extractors, perHost)) {
+            result = crawler.download(url, depth);
+        }
+        if (Objects.nonNull(result)) {
+            result.getDownloaded().forEach(System.out::println);
+            result.getErrors().forEach((k, v) -> System.err.printf("Error on url %s: %s\n", k, String.valueOf(v)));
+        }
     }
 }


### PR DESCRIPTION
The solution is for hard version of the task.
Proof:
```
/usr/lib/jvm/java-8-jdk/bin/java -Dvisualvm.id=873794022447432 -ea -javaagent:/opt/intellij-idea-ce-eap/lib/idea_rt.jar=36155:/opt/intellij-idea-ce-eap/bin -Dfile.encoding=UTF-8 -classpath /usr/lib/jvm/java-8-jdk/jre/lib/charsets.jar:/usr/lib/jvm/java-8-jdk/jre/lib/deploy.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/cldrdata.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/dnsns.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/jaccess.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/jfxrt.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/localedata.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/nashorn.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/sunec.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/sunjce_provider.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/sunpkcs11.jar:/usr/lib/jvm/java-8-jdk/jre/lib/ext/zipfs.jar:/usr/lib/jvm/java-8-jdk/jre/lib/javaws.jar:/usr/lib/jvm/java-8-jdk/jre/lib/jce.jar:/usr/lib/jvm/java-8-jdk/jre/lib/jfr.jar:/usr/lib/jvm/java-8-jdk/jre/lib/jfxswt.jar:/usr/lib/jvm/java-8-jdk/jre/lib/jsse.jar:/usr/lib/jvm/java-8-jdk/jre/lib/management-agent.jar:/usr/lib/jvm/java-8-jdk/jre/lib/plugin.jar:/usr/lib/jvm/java-8-jdk/jre/lib/resources.jar:/usr/lib/jvm/java-8-jdk/jre/lib/rt.jar:/home/alx/projects/Java/Advanced/Tasks/out/production/Crawler:/home/alx/uni/ifmo/M4105/java/java-advanced-2017/artifacts/WebCrawlerTest.jar:/home/alx/projects/Java/Advanced/Tasks/out/production/Mapper:/home/alx/uni/ifmo/M4105/java/java-advanced-2017/artifacts/ParallelMapperTest.jar:/home/alx/uni/ifmo/M4105/java/java-advanced-2017/lib/junit-4.11.jar:/home/alx/uni/ifmo/M4105/java/java-advanced-2017/lib/quickcheck-0.6.jar:/home/alx/uni/ifmo/M4105/java/java-advanced-2017/lib/jsoup-1.8.1.jar:/home/alx/uni/ifmo/M4105/java/java-advanced-2017/lib/hamcrest-core-1.3.jar:/home/alx/uni/ifmo/M4105/java/java-advanced-2017/artifacts/IterativeParallelismTest.jar:/home/alx/projects/Java/Advanced/Tasks/out/production/IP info.kgeorgiy.java.advanced.crawler.Tester hard ru.ifmo.ctddev.dyadyushkin.crawler.WebCrawler
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true
=== Running test10_singleConnectionPerHost
    100 of 210 pages downloaded, 0 errors
    200 of 210 pages downloaded, 0 errors
=== Running test11_limitedConnectionsPerHost
    100 of 210 pages downloaded, 0 errors
    200 of 210 pages downloaded, 0 errors
=== Running test12_limitedConnectionsPerformance
    100 of 210 pages downloaded, 0 errors
    200 of 210 pages downloaded, 0 errors
Time: 2629
=== Running test01_singlePage
=== Running test02_pageAndLinks
    100 of 210 pages downloaded, 0 errors
    200 of 210 pages downloaded, 0 errors
=== Running test03_deep
    100 of 614 pages downloaded, 3 errors
    200 of 614 pages downloaded, 3 errors
    300 of 614 pages downloaded, 6 errors
    400 of 614 pages downloaded, 6 errors
    500 of 614 pages downloaded, 14 errors
    600 of 614 pages downloaded, 25 errors
=== Running test04_shallow
=== Running test05_noLimits
    100 of 339 pages downloaded, 0 errors
    200 of 339 pages downloaded, 0 errors
    300 of 339 pages downloaded, 0 errors
=== Running test06_limitDownloads
    100 of 339 pages downloaded, 0 errors
    200 of 339 pages downloaded, 0 errors
    300 of 339 pages downloaded, 0 errors
=== Running test07_limitExtractors
    100 of 339 pages downloaded, 0 errors
    200 of 339 pages downloaded, 0 errors
    300 of 339 pages downloaded, 0 errors
=== Running test08_limitBoth
    100 of 339 pages downloaded, 0 errors
    200 of 339 pages downloaded, 0 errors
    300 of 339 pages downloaded, 0 errors
=== Running test09_performance
    100 of 339 pages downloaded, 0 errors
    200 of 339 pages downloaded, 0 errors
    300 of 339 pages downloaded, 0 errors
Time: 4708
============================
OK CrawlerHardTest for ru.ifmo.ctddev.dyadyushkin.crawler.WebCrawler
Class: CrawlerHardTest
Salt: 
Certificate: fk7E+hs9jkhgIAG3JeH4iXhiUZM=
+-----------+
|         ..|
|         : |
|   ..    ::|
|  o.:   ..:|
|   |X.   ..|
|   Xo.   ..|
|    ::    :|
|   .... :: |
|    : ...:o|
|    .  ...o|
|        :o:|
+-----------+

Process finished with exit code 0
```